### PR TITLE
ec2: bump API version for RunInstances

### DIFF
--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -129,15 +129,11 @@ func (s *S) TestRunInstancesExample(c *C) {
 			}},
 		}},
 	}
-	params := ec2.PrepareRunParams(options)
-	c.Assert(params, DeepEquals, map[string]string{
-		"Version": "2013-10-15",
-		"Action":  "RunInstances",
-	})
 	resp, err := s.ec2.RunInstances(&options)
 
 	req := testServer.WaitRequest()
 	c.Assert(req.Form["Action"], DeepEquals, []string{"RunInstances"})
+	c.Assert(req.Form["Version"], DeepEquals, []string{"2014-10-01"})
 	c.Assert(req.Form["ImageId"], DeepEquals, []string{"image-id"})
 	c.Assert(req.Form["MinCount"], DeepEquals, []string{"1"})
 	c.Assert(req.Form["MaxCount"], DeepEquals, []string{"1"})

--- a/ec2/export_test.go
+++ b/ec2/export_test.go
@@ -15,5 +15,3 @@ func FakeTime(fakeIt bool) {
 		timeNow = time.Now
 	}
 }
-
-var PrepareRunParams = prepareRunParams


### PR DESCRIPTION
This is needed to support BlockDeviceMapping.n.Ebs.{VolumeType,Iops,Encrypted}.

I've been through the differences between 2011-12-15 (what was being used) and
2014-10-01 (current AWS API), and I've found the following differences:
- AddressingType only in old; marked deprecated
- BlockDeviceMapping.n.Ebs.{VolumeType,Iops,Encrypted} only in new
- NetworkInterface.n.PrivateIpAddresses.n.{PrivateIpAddress,Primary}
  only in new
- NetworkInterface.n.{Secondary,Associate}PrivateIpAddressCount only
  in new
- IamInstanceProfile.Arn only in new

None of the new fields are required, and the defaults match the existing
behaviour.
