### PR TITLE
Upgraded AWS API version to 2014-10-01 (latest)

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -300,7 +300,7 @@ type Instance struct {
 	AvailZone          string             `xml:"placement>availabilityZone"`
 	AssociatePublicIP  bool               `xml:"associatePublicIpAddress,omitempty"`
 	PlacementGroupName string             `xml:"placement>groupName"`
-	EbsOptimized       bool               `xml:"ebsOptimized,omitempty"`
+	EBSOptimized       bool               `xml:"ebsOptimized,omitempty"`
 	SRIOVNetSupport    bool               `xml:"sriovNetSupport,omitempty"`
 	State              InstanceState      `xml:"instanceState"`
 	Tags               []Tag              `xml:"tagSet>item"`

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -777,28 +777,8 @@ type IPPerm struct {
 	Protocol     string              `xml:"ipProtocol"`
 	FromPort     int                 `xml:"fromPort"`
 	ToPort       int                 `xml:"toPort"`
-	SourceIPs    []SourceIP          `xml:"ipRanges>item"`
+	SourceIPs    []string            `xml:"ipRanges>item>cidrIp"`
 	SourceGroups []UserSecurityGroup `xml:"groups>item"`
-}
-
-// SourceIP represents a single security group source IP address
-// within an ingress permission rule.
-//
-// See http://goo.gl/4oTxv for more details.
-type SourceIP struct {
-	IP string `xml:"cidrIp"`
-}
-
-// SourceIPs is a helper for constructing []SourceIP from strings.
-func SourceIPs(ips ...string) []SourceIP {
-	if len(ips) == 0 {
-		return nil
-	}
-	result := make([]SourceIP, len(ips))
-	for i, ip := range ips {
-		result[i].IP = ip
-	}
-	return result
 }
 
 // UserSecurityGroup holds a security group and the owner
@@ -912,7 +892,7 @@ func (ec2 *EC2) authOrRevoke(op string, group SecurityGroup, perms []IPPerm) (re
 		params[prefix+".FromPort"] = strconv.Itoa(perm.FromPort)
 		params[prefix+".ToPort"] = strconv.Itoa(perm.ToPort)
 		for j, ip := range perm.SourceIPs {
-			params[prefix+".IpRanges."+strconv.Itoa(j+1)+".CidrIp"] = ip.IP
+			params[prefix+".IpRanges."+strconv.Itoa(j+1)+".CidrIp"] = ip
 		}
 		for j, g := range perm.SourceGroups {
 			subprefix := prefix + ".Groups." + strconv.Itoa(j+1)

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -534,7 +534,7 @@ func (s *S) TestDescribeSecurityGroupsExample(c *C) {
 	c.Assert(g0ipp.Protocol, Equals, "tcp")
 	c.Assert(g0ipp.FromPort, Equals, 80)
 	c.Assert(g0ipp.ToPort, Equals, 80)
-	c.Assert(g0ipp.SourceIPs, DeepEquals, ec2.SourceIPs("0.0.0.0/0"))
+	c.Assert(g0ipp.SourceIPs, DeepEquals, []string{"0.0.0.0/0"})
 
 	g1 := resp.Groups[1]
 	c.Assert(g1.OwnerId, Equals, "999988887777")
@@ -635,7 +635,7 @@ func (s *S) TestAuthorizeSecurityGroupExample1(c *C) {
 		Protocol:  "tcp",
 		FromPort:  80,
 		ToPort:    80,
-		SourceIPs: ec2.SourceIPs("205.192.0.0/16", "205.159.0.0/16"),
+		SourceIPs: []string{"205.192.0.0/16", "205.159.0.0/16"},
 	}}
 	resp, err := s.ec2.AuthorizeSecurityGroup(ec2.SecurityGroup{Name: "websrv"}, perms)
 
@@ -660,7 +660,7 @@ func (s *S) TestAuthorizeSecurityGroupExample1WithId(c *C) {
 		Protocol:  "tcp",
 		FromPort:  80,
 		ToPort:    80,
-		SourceIPs: ec2.SourceIPs("205.192.0.0/16", "205.159.0.0/16"),
+		SourceIPs: []string{"205.192.0.0/16", "205.159.0.0/16"},
 	}}
 	// ignore return and error - we're only want to check the parameter handling.
 	s.ec2.AuthorizeSecurityGroup(ec2.SecurityGroup{Id: "sg-67ad940e", Name: "ignored"}, perms)

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -129,11 +129,6 @@ func (s *S) TestRunInstancesExample(c *C) {
 			}},
 		}},
 	}
-	params := ec2.PrepareRunParams(options)
-	c.Assert(params, DeepEquals, map[string]string{
-		"Version": "2013-10-15",
-		"Action":  "RunInstances",
-	})
 	resp, err := s.ec2.RunInstances(&options)
 
 	req := testServer.WaitRequest()
@@ -504,12 +499,12 @@ func (s *S) checkCreateSGResponse(c *C, resp *ec2.CreateSecurityGroupResp, id, n
 
 func (s *S) TestCreateSecurityGroupExample(c *C) {
 	testServer.Response(200, nil, CreateSecurityGroupExample)
-	resp, err := s.ec2.CreateSecurityGroup("websrv", "Web Servers")
+	resp, err := s.ec2.CreateSecurityGroup("", "websrv", "Web Servers")
 	c.Assert(err, IsNil)
 	s.checkCreateSGResponse(c, resp, "sg-67ad940e", "websrv", "Web Servers", "")
 
 	testServer.Response(200, nil, CreateSecurityGroupExample)
-	resp, err = s.ec2.CreateSecurityGroupVPC("vpc-id", "websrv", "Web Servers")
+	resp, err = s.ec2.CreateSecurityGroup("vpc-id", "websrv", "Web Servers")
 	c.Assert(err, IsNil)
 	s.checkCreateSGResponse(c, resp, "sg-67ad940e", "websrv", "Web Servers", "vpc-id")
 }
@@ -539,7 +534,7 @@ func (s *S) TestDescribeSecurityGroupsExample(c *C) {
 	c.Assert(g0ipp.Protocol, Equals, "tcp")
 	c.Assert(g0ipp.FromPort, Equals, 80)
 	c.Assert(g0ipp.ToPort, Equals, 80)
-	c.Assert(g0ipp.SourceIPs, DeepEquals, []string{"0.0.0.0/0"})
+	c.Assert(g0ipp.SourceIPs, DeepEquals, ec2.SourceIPs("0.0.0.0/0"))
 
 	g1 := resp.Groups[1]
 	c.Assert(g1.OwnerId, Equals, "999988887777")
@@ -640,7 +635,7 @@ func (s *S) TestAuthorizeSecurityGroupExample1(c *C) {
 		Protocol:  "tcp",
 		FromPort:  80,
 		ToPort:    80,
-		SourceIPs: []string{"205.192.0.0/16", "205.159.0.0/16"},
+		SourceIPs: ec2.SourceIPs("205.192.0.0/16", "205.159.0.0/16"),
 	}}
 	resp, err := s.ec2.AuthorizeSecurityGroup(ec2.SecurityGroup{Name: "websrv"}, perms)
 
@@ -665,7 +660,7 @@ func (s *S) TestAuthorizeSecurityGroupExample1WithId(c *C) {
 		Protocol:  "tcp",
 		FromPort:  80,
 		ToPort:    80,
-		SourceIPs: []string{"205.192.0.0/16", "205.159.0.0/16"},
+		SourceIPs: ec2.SourceIPs("205.192.0.0/16", "205.159.0.0/16"),
 	}}
 	// ignore return and error - we're only want to check the parameter handling.
 	s.ec2.AuthorizeSecurityGroup(ec2.SecurityGroup{Id: "sg-67ad940e", Name: "ignored"}, perms)

--- a/ec2/ec2i_test.go
+++ b/ec2/ec2i_test.go
@@ -109,13 +109,13 @@ func (s *ClientTests) TestSecurityGroups(c *C) {
 	s.ec2.DeleteSecurityGroup(ec2.SecurityGroup{Name: name})
 	defer s.ec2.DeleteSecurityGroup(ec2.SecurityGroup{Name: name})
 
-	resp1, err := s.ec2.CreateSecurityGroup(name, descr)
+	resp1, err := s.ec2.CreateSecurityGroup("", name, descr)
 	c.Assert(err, IsNil)
 	c.Assert(resp1.RequestId, Matches, ".+")
 	c.Assert(resp1.Name, Equals, name)
 	c.Assert(resp1.Id, Matches, ".+")
 
-	resp1, err = s.ec2.CreateSecurityGroup(name, descr)
+	resp1, err = s.ec2.CreateSecurityGroup("", name, descr)
 	ec2err, _ := err.(*ec2.Error)
 	c.Assert(resp1, IsNil)
 	c.Assert(ec2err, NotNil)
@@ -125,7 +125,7 @@ func (s *ClientTests) TestSecurityGroups(c *C) {
 		Protocol:  "tcp",
 		FromPort:  0,
 		ToPort:    1024,
-		SourceIPs: []string{"127.0.0.1/24"},
+		SourceIPs: ec2.SourceIPs("127.0.0.0/24"),
 	}}
 
 	resp2, err := s.ec2.AuthorizeSecurityGroup(ec2.SecurityGroup{Name: name}, perms)
@@ -144,7 +144,7 @@ func (s *ClientTests) TestSecurityGroups(c *C) {
 	c.Assert(g0.IPPerms[0].Protocol, Equals, "tcp")
 	c.Assert(g0.IPPerms[0].FromPort, Equals, 0)
 	c.Assert(g0.IPPerms[0].ToPort, Equals, 1024)
-	c.Assert(g0.IPPerms[0].SourceIPs, DeepEquals, []string{"127.0.0.1/24"})
+	c.Assert(g0.IPPerms[0].SourceIPs, DeepEquals, ec2.SourceIPs("127.0.0.0/24"))
 
 	resp2, err = s.ec2.DeleteSecurityGroup(ec2.SecurityGroup{Name: name})
 	c.Assert(err, IsNil)
@@ -179,7 +179,7 @@ func (s *ClientTests) TestRegions(c *C) {
 		Protocol:  "tcp",
 		FromPort:  80,
 		ToPort:    80,
-		SourceIPs: []string{"127.0.0.1/32"},
+		SourceIPs: ec2.SourceIPs("127.0.0.1/32"),
 	}}
 	errs := make(chan error, len(allRegions))
 	for _, region := range allRegions {

--- a/ec2/ec2i_test.go
+++ b/ec2/ec2i_test.go
@@ -125,7 +125,7 @@ func (s *ClientTests) TestSecurityGroups(c *C) {
 		Protocol:  "tcp",
 		FromPort:  0,
 		ToPort:    1024,
-		SourceIPs: ec2.SourceIPs("127.0.0.0/24"),
+		SourceIPs: []string{"127.0.0.0/24"},
 	}}
 
 	resp2, err := s.ec2.AuthorizeSecurityGroup(ec2.SecurityGroup{Name: name}, perms)
@@ -144,7 +144,7 @@ func (s *ClientTests) TestSecurityGroups(c *C) {
 	c.Assert(g0.IPPerms[0].Protocol, Equals, "tcp")
 	c.Assert(g0.IPPerms[0].FromPort, Equals, 0)
 	c.Assert(g0.IPPerms[0].ToPort, Equals, 1024)
-	c.Assert(g0.IPPerms[0].SourceIPs, DeepEquals, ec2.SourceIPs("127.0.0.0/24"))
+	c.Assert(g0.IPPerms[0].SourceIPs, DeepEquals, []string{"127.0.0.0/24"})
 
 	resp2, err = s.ec2.DeleteSecurityGroup(ec2.SecurityGroup{Name: name})
 	c.Assert(err, IsNil)
@@ -179,7 +179,7 @@ func (s *ClientTests) TestRegions(c *C) {
 		Protocol:  "tcp",
 		FromPort:  80,
 		ToPort:    80,
-		SourceIPs: ec2.SourceIPs("127.0.0.1/32"),
+		SourceIPs: []string{"127.0.0.1/32"},
 	}}
 	errs := make(chan error, len(allRegions))
 	for _, region := range allRegions {

--- a/ec2/ec2t_test.go
+++ b/ec2/ec2t_test.go
@@ -483,7 +483,7 @@ func (s *ServerTests) TestIPPerms(c *C) {
 		Protocol:  "tcp",
 		FromPort:  0,
 		ToPort:    1024,
-		SourceIPs: ec2.SourceIPs("invalid"),
+		SourceIPs: []string{"invalid"},
 	}})
 	c.Assert(err, NotNil)
 	c.Check(errorCode(err), Equals, "InvalidParameterValue")
@@ -493,7 +493,7 @@ func (s *ServerTests) TestIPPerms(c *C) {
 		Protocol:  "tcp",
 		FromPort:  2000,
 		ToPort:    2001,
-		SourceIPs: ec2.SourceIPs("127.0.0.0/24"),
+		SourceIPs: []string{"127.0.0.0/24"},
 		SourceGroups: []ec2.UserSecurityGroup{{
 			Name: g1.Name,
 		}, {
@@ -503,7 +503,7 @@ func (s *ServerTests) TestIPPerms(c *C) {
 		Protocol:  "tcp",
 		FromPort:  2000,
 		ToPort:    2001,
-		SourceIPs: ec2.SourceIPs("200.1.1.34/32"),
+		SourceIPs: []string{"200.1.1.34/32"},
 	}})
 	c.Assert(err, IsNil)
 
@@ -527,7 +527,7 @@ func (s *ServerTests) TestIPPerms(c *C) {
 			// Only source IPs should exist.
 			c.Check(sourceGroups, IsNil)
 			c.Check(sourceIPs, HasLen, 2)
-			c.Check(sourceIPs, DeepEquals, ec2.SourceIPs("127.0.0.0/24", "200.1.1.34/32"))
+			c.Check(sourceIPs, DeepEquals, []string{"127.0.0.0/24", "200.1.1.34/32"})
 		}
 		c.Check(ipperm.Protocol, Equals, "tcp")
 		c.Check(ipperm.FromPort, Equals, 2000)
@@ -550,7 +550,7 @@ func (s *ServerTests) TestIPPerms(c *C) {
 		FromPort:     2000,
 		ToPort:       2001,
 		SourceGroups: nil,
-		SourceIPs:    ec2.SourceIPs("200.1.1.34/32"),
+		SourceIPs:    []string{"200.1.1.34/32"},
 	}})
 	c.Assert(err, IsNil)
 
@@ -572,7 +572,7 @@ func (s *ServerTests) TestIPPerms(c *C) {
 			// Only source IPs should exist.
 			c.Check(sourceGroups, IsNil)
 			c.Check(sourceIPs, HasLen, 1)
-			c.Check(sourceIPs, DeepEquals, ec2.SourceIPs("127.0.0.0/24"))
+			c.Check(sourceIPs, DeepEquals, []string{"127.0.0.0/24"})
 		}
 		c.Check(ipperm.Protocol, Equals, "tcp")
 		c.Check(ipperm.FromPort, Equals, 2000)
@@ -609,12 +609,12 @@ func (s *ServerTests) TestDuplicateIPPerm(c *C) {
 		Protocol:  "tcp",
 		FromPort:  200,
 		ToPort:    1024,
-		SourceIPs: ec2.SourceIPs("127.0.0.1/24"),
+		SourceIPs: []string{"127.0.0.1/24"},
 	}, {
 		Protocol:  "tcp",
 		FromPort:  0,
 		ToPort:    100,
-		SourceIPs: ec2.SourceIPs("127.0.0.1/24"),
+		SourceIPs: []string{"127.0.0.1/24"},
 	}}
 
 	_, err = s.ec2.AuthorizeSecurityGroup(ec2.SecurityGroup{Name: name}, perms[0:1])
@@ -943,7 +943,7 @@ func (s *ServerTests) TestGroupFiltering(c *C) {
 		Protocol:  "tcp",
 		FromPort:  100,
 		ToPort:    200,
-		SourceIPs: ec2.SourceIPs("1.2.3.4/32"),
+		SourceIPs: []string{"1.2.3.4/32"},
 	}}, {{
 		Protocol:     "tcp",
 		FromPort:     200,

--- a/ec2/export_test.go
+++ b/ec2/export_test.go
@@ -15,5 +15,3 @@ func FakeTime(fakeIt bool) {
 		timeNow = time.Now
 	}
 }
-
-var PrepareRunParams = prepareRunParams

--- a/ec2/networkinterfaces.go
+++ b/ec2/networkinterfaces.go
@@ -97,7 +97,7 @@ type CreateNetworkInterfaceResp struct {
 //
 // See http://goo.gl/ze3VhA for more details.
 func (ec2 *EC2) CreateNetworkInterface(opts CreateNetworkInterface) (resp *CreateNetworkInterfaceResp, err error) {
-	params := makeParamsVPC("CreateNetworkInterface")
+	params := makeParams("CreateNetworkInterface")
 	params["SubnetId"] = opts.SubnetId
 	for i, ip := range opts.PrivateIPs {
 		prefix := fmt.Sprintf("PrivateIpAddresses.%d.", i+1)
@@ -127,7 +127,7 @@ func (ec2 *EC2) CreateNetworkInterface(opts CreateNetworkInterface) (resp *Creat
 //
 // See http://goo.gl/MC1yOj for more details.
 func (ec2 *EC2) DeleteNetworkInterface(id string) (resp *SimpleResp, err error) {
-	params := makeParamsVPC("DeleteNetworkInterface")
+	params := makeParams("DeleteNetworkInterface")
 	params["NetworkInterfaceId"] = id
 	resp = &SimpleResp{}
 	err = ec2.query(params, resp)
@@ -153,7 +153,7 @@ type NetworkInterfacesResp struct {
 //
 // See http://goo.gl/2LcXtM for more details.
 func (ec2 *EC2) NetworkInterfaces(ids []string, filter *Filter) (resp *NetworkInterfacesResp, err error) {
-	params := makeParamsVPC("DescribeNetworkInterfaces")
+	params := makeParams("DescribeNetworkInterfaces")
 	for i, id := range ids {
 		params["NetworkInterfaceId."+strconv.Itoa(i+1)] = id
 	}
@@ -180,7 +180,7 @@ type AttachNetworkInterfaceResp struct {
 //
 // See http://goo.gl/rEbSii for more details.
 func (ec2 *EC2) AttachNetworkInterface(interfaceId, instanceId string, deviceIndex int) (resp *AttachNetworkInterfaceResp, err error) {
-	params := makeParamsVPC("AttachNetworkInterface")
+	params := makeParams("AttachNetworkInterface")
 	params["NetworkInterfaceId"] = interfaceId
 	params["InstanceId"] = instanceId
 	params["DeviceIndex"] = strconv.Itoa(deviceIndex)
@@ -197,7 +197,7 @@ func (ec2 *EC2) AttachNetworkInterface(interfaceId, instanceId string, deviceInd
 //
 // See http://goo.gl/0Xc1px for more details.
 func (ec2 *EC2) DetachNetworkInterface(attachmentId string, force bool) (resp *SimpleResp, err error) {
-	params := makeParamsVPC("DetachNetworkInterface")
+	params := makeParams("DetachNetworkInterface")
 	params["AttachmentId"] = attachmentId
 	if force {
 		// Force is optional.

--- a/ec2/networkinterfaces_test.go
+++ b/ec2/networkinterfaces_test.go
@@ -202,7 +202,7 @@ func (s *ServerTests) TestNetworkInterfaces(c *C) {
 	subId := subResp.Subnet.Id
 	defer s.deleteSubnets(c, []string{subId})
 
-	sg := s.makeTestGroupVPC(c, vpcId, "vpc-sg-1", "vpc test group1")
+	sg := s.makeTestGroup(c, vpcId, "vpc-sg-1", "vpc test group1")
 	defer s.deleteGroups(c, []ec2.SecurityGroup{sg})
 
 	instList, err := s.ec2.RunInstances(&ec2.RunInstances{

--- a/ec2/privateips.go
+++ b/ec2/privateips.go
@@ -24,7 +24,7 @@ import (
 //
 // See http://goo.gl/MoeH0L more details.
 func (ec2 *EC2) AssignPrivateIPAddresses(interfaceId string, ipAddresses []string, secondaryIPCount int, allowReassignment bool) (resp *SimpleResp, err error) {
-	params := makeParamsVPC("AssignPrivateIpAddresses")
+	params := makeParams("AssignPrivateIpAddresses")
 	params["NetworkInterfaceId"] = interfaceId
 	if secondaryIPCount > 0 {
 		params["SecondaryPrivateIpAddressCount"] = strconv.Itoa(secondaryIPCount)
@@ -51,7 +51,7 @@ func (ec2 *EC2) AssignPrivateIPAddresses(interfaceId string, ipAddresses []strin
 //
 // See http://goo.gl/RjGZdB for more details.
 func (ec2 *EC2) UnassignPrivateIPAddresses(interfaceId string, ipAddresses []string) (resp *SimpleResp, err error) {
-	params := makeParamsVPC("UnassignPrivateIpAddresses")
+	params := makeParams("UnassignPrivateIpAddresses")
 	params["NetworkInterfaceId"] = interfaceId
 	for i, ip := range ipAddresses {
 		// PrivateIpAddress is zero indexed.

--- a/ec2/responses_test.go
+++ b/ec2/responses_test.go
@@ -2,16 +2,22 @@ package ec2_test
 
 var ErrorDump = `
 <?xml version="1.0" encoding="UTF-8"?>
-<Response><Errors><Error><Code>UnsupportedOperation</Code>
-<Message>AMIs with an instance-store root device are not supported for the instance type 't1.micro'.</Message>
-</Error></Errors><RequestID>0503f4e9-bbd6-483c-b54f-c4ae9f3b30f4</RequestID></Response>
+<Response>
+   <Errors>
+      <Error>
+         <Code>UnsupportedOperation</Code>
+         <Message>AMIs with an instance-store root device are not supported for the instance type 't1.micro'.</Message>
+      </Error>
+   </Errors>
+   <RequestID>0503f4e9-bbd6-483c-b54f-c4ae9f3b30f4</RequestID>
+</Response>
 `
 
 // http://goo.gl/Mcm3b
 var RunInstancesExample = `
-<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-13/"> 
-  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
-  <reservationId>r-47a5402e</reservationId> 
+<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+  <reservationId>r-47a5402e</reservationId>
   <ownerId>999988887777</ownerId>
   <groupSet>
       <item>
@@ -171,8 +177,8 @@ var RunInstancesExample = `
 
 // http://goo.gl/3BKHj
 var TerminateInstancesExample = `
-<TerminateInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
-  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+<TerminateInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <instancesSet>
     <item>
       <instanceId>i-3ea74257</instanceId>
@@ -191,7 +197,7 @@ var TerminateInstancesExample = `
 
 // http://goo.gl/mLbmw
 var DescribeInstancesExample1 = `
-<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
   <requestId>98e3c9a4-848c-4d6d-8e8a-b1bdEXAMPLE</requestId>
   <reservationSet>
     <item>
@@ -326,8 +332,8 @@ var DescribeInstancesExample1 = `
 
 // http://goo.gl/mLbmw
 var DescribeInstancesExample2 = `
-<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/"> 
-  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <reservationSet>
     <item>
       <reservationId>r-bc7e30d7</reservationId>
@@ -399,7 +405,7 @@ var DescribeInstancesExample2 = `
 
 // http://goo.gl/V0U25
 var DescribeImagesExample = `
-<DescribeImagesResponse xmlns="http://ec2.amazonaws.com/doc/2012-08-15/">
+<DescribeImagesResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
          <requestId>4a4a27a2-2e7c-475d-b35b-ca822EXAMPLE</requestId>
     <imagesSet>
         <item>
@@ -441,7 +447,7 @@ var DescribeImagesExample = `
 
 // http://goo.gl/ttcda
 var CreateSnapshotExample = `
-<CreateSnapshotResponse xmlns="http://ec2.amazonaws.com/doc/2012-10-01/">
+<CreateSnapshotResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <snapshotId>snap-78a54011</snapshotId>
   <volumeId>vol-4d826724</volumeId>
@@ -456,16 +462,16 @@ var CreateSnapshotExample = `
 
 // http://goo.gl/vwU1y
 var DeleteSnapshotExample = `
-<DeleteSnapshotResponse xmlns="http://ec2.amazonaws.com/doc/2012-10-01/">
-  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+<DeleteSnapshotResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <return>true</return>
 </DeleteSnapshotResponse>
 `
 
 // http://goo.gl/nkovs
 var DescribeSnapshotsExample = `
-<DescribeSnapshotsResponse xmlns="http://ec2.amazonaws.com/doc/2012-10-01/">
-   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+<DescribeSnapshotsResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
    <snapshotSet>
       <item>
          <snapshotId>snap-1a2b3c4d</snapshotId>
@@ -489,7 +495,7 @@ var DescribeSnapshotsExample = `
 
 // http://goo.gl/Eo7Yl
 var CreateSecurityGroupExample = `
-<CreateSecurityGroupResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+<CreateSecurityGroupResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
    <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
    <return>true</return>
    <groupId>sg-67ad940e</groupId>
@@ -498,8 +504,8 @@ var CreateSecurityGroupExample = `
 
 // http://goo.gl/k12Uy
 var DescribeSecurityGroupsExample = `
-<DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
-  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+<DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <securityGroupInfo>
     <item>
       <ownerId>999988887777</ownerId>
@@ -542,7 +548,7 @@ var DescribeSecurityGroupsExample = `
 // A dump which includes groups within ip permissions.
 var DescribeSecurityGroupsDump = `
 <?xml version="1.0" encoding="UTF-8"?>
-<DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+<DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
     <requestId>87b92b57-cc6e-48b2-943f-f6f0e5c9f46c</requestId>
     <securityGroupInfo>
         <item>
@@ -584,7 +590,7 @@ var DescribeSecurityGroupsDump = `
 
 // http://goo.gl/QJJDO
 var DeleteSecurityGroupExample = `
-<DeleteSecurityGroupResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+<DeleteSecurityGroupResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
    <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
    <return>true</return>
 </DeleteSecurityGroupResponse>
@@ -592,7 +598,7 @@ var DeleteSecurityGroupExample = `
 
 // http://goo.gl/u2sDJ
 var AuthorizeSecurityGroupIngressExample = `
-<AuthorizeSecurityGroupIngressResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+<AuthorizeSecurityGroupIngressResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <return>true</return>
 </AuthorizeSecurityGroupIngressResponse>
@@ -600,15 +606,15 @@ var AuthorizeSecurityGroupIngressExample = `
 
 // http://goo.gl/Mz7xr
 var RevokeSecurityGroupIngressExample = `
-<RevokeSecurityGroupIngressResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
-  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+<RevokeSecurityGroupIngressResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <return>true</return>
 </RevokeSecurityGroupIngressResponse>
 `
 
 // http://goo.gl/Vmkqc
 var CreateTagsExample = `
-<CreateTagsResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+<CreateTagsResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
    <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
    <return>true</return>
 </CreateTagsResponse>
@@ -616,8 +622,8 @@ var CreateTagsExample = `
 
 // http://goo.gl/awKeF
 var StartInstancesExample = `
-<StartInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
-  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>   
+<StartInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <instancesSet>
     <item>
       <instanceId>i-10a64379</instanceId>
@@ -636,8 +642,8 @@ var StartInstancesExample = `
 
 // http://goo.gl/436dJ
 var StopInstancesExample = `
-<StopInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
-  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+<StopInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <instancesSet>
     <item>
       <instanceId>i-10a64379</instanceId>
@@ -656,7 +662,7 @@ var StopInstancesExample = `
 
 // http://goo.gl/baoUf
 var RebootInstancesExample = `
-<RebootInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">
+<RebootInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <return>true</return>
 </RebootInstancesResponse>
@@ -665,7 +671,7 @@ var RebootInstancesExample = `
 // http://goo.gl/ylxT4R
 var DescribeAvailabilityZonesExample1 = `
 <DescribeAvailabilityZonesResponse xmlns="http://ec2.amazonaws.com/doc/2014-05-01/">
-   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
    <availabilityZoneInfo>
    <item>
       <zoneName>us-east-1a</zoneName>
@@ -697,8 +703,8 @@ var DescribeAvailabilityZonesExample1 = `
 
 // http://goo.gl/ylxT4R
 var DescribeAvailabilityZonesExample2 = `
-<DescribeAvailabilityZonesResponse xmlns="http://ec2.amazonaws.com/doc/2014-05-01/">
-   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+<DescribeAvailabilityZonesResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
    <availabilityZoneInfo>
    <item>
       <zoneName>us-east-1a</zoneName>
@@ -720,7 +726,7 @@ var DescribeAvailabilityZonesExample2 = `
 
 // http://goo.gl/nkwjv
 var CreateVpcExample = `
-<CreateVpcResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<CreateVpcResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
    <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
    <vpc>
       <vpcId>vpc-1a2b3c4d</vpcId>
@@ -735,7 +741,7 @@ var CreateVpcExample = `
 
 // http://goo.gl/bcxtbf
 var DeleteVpcExample = `
-<DeleteVpcResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DeleteVpcResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
    <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
    <return>true</return>
 </DeleteVpcResponse>
@@ -743,7 +749,7 @@ var DeleteVpcExample = `
 
 // http://goo.gl/Y5kHqG
 var DescribeVpcsExample = `
-<DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
   <vpcSet>
     <item>
@@ -761,7 +767,7 @@ var DescribeVpcsExample = `
 
 // http://goo.gl/wLPhf
 var CreateSubnetExample = `
-<CreateSubnetResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<CreateSubnetResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
   <subnet>
     <subnetId>subnet-9d4a7b6c</subnetId>
@@ -777,7 +783,7 @@ var CreateSubnetExample = `
 
 // http://goo.gl/KmhcBM
 var DeleteSubnetExample = `
-<DeleteSubnetResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DeleteSubnetResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
    <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
    <return>true</return>
 </DeleteSubnetResponse>
@@ -785,7 +791,7 @@ var DeleteSubnetExample = `
 
 // http://goo.gl/NTKQVI
 var DescribeSubnetsExample = `
-<DescribeSubnetsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeSubnetsResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
   <subnetSet>
     <item>
@@ -816,7 +822,7 @@ var DescribeSubnetsExample = `
 
 // http://goo.gl/ze3VhA
 var CreateNetworkInterfaceExample = `
-<CreateNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<CreateNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
  <requestId>8dbe591e-5a22-48cb-b948-dd0aadd55adf</requestId>
     <networkInterface>
         <networkInterfaceId>eni-cfca76a6</networkInterfaceId>
@@ -849,7 +855,7 @@ var CreateNetworkInterfaceExample = `
 
 // http://goo.gl/MC1yOj
 var DeleteNetworkInterfaceExample = `
-<DeleteNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DeleteNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
     <requestId>e1c6d73b-edaa-4e62-9909-6611404e1739</requestId>
     <return>true</return>
 </DeleteNetworkInterfaceResponse>
@@ -857,7 +863,7 @@ var DeleteNetworkInterfaceExample = `
 
 // http://goo.gl/2LcXtM
 var DescribeNetworkInterfacesExample = `
-<DescribeNetworkInterfacesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeNetworkInterfacesResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
     <requestId>fc45294c-006b-457b-bab9-012f5b3b0e40</requestId>
      <networkInterfaceSet>
        <item>
@@ -948,7 +954,7 @@ var DescribeNetworkInterfacesExample = `
 
 // http://goo.gl/rEbSii
 var AttachNetworkInterfaceExample = `
-<AttachNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<AttachNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
     <requestId>ace8cd1e-e685-4e44-90fb-92014d907212</requestId>
     <attachmentId>eni-attach-d94b09b0</attachmentId>
 </AttachNetworkInterfaceResponse>
@@ -956,7 +962,7 @@ var AttachNetworkInterfaceExample = `
 
 // http://goo.gl/0Xc1px
 var DetachNetworkInterfaceExample = `
-<DetachNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DetachNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
     <requestId>ce540707-0635-46bc-97da-33a8a362a0e8</requestId>
     <return>true</return>
 </DetachNetworkInterfaceResponse>
@@ -964,7 +970,7 @@ var DetachNetworkInterfaceExample = `
 
 // http://goo.gl/MoeH0L
 var AssignPrivateIpAddressesExample = `
-<AssignPrivateIpAddresses xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<AssignPrivateIpAddresses xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
    <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
    <return>true</return>
 </AssignPrivateIpAddresses>
@@ -972,7 +978,7 @@ var AssignPrivateIpAddressesExample = `
 
 // http://goo.gl/RjGZdB
 var UnassignPrivateIpAddressesExample = `
-<UnassignPrivateIpAddresses xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<UnassignPrivateIpAddresses xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
    <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
    <return>true</return>
 </UnassignPrivateIpAddresses>
@@ -980,7 +986,7 @@ var UnassignPrivateIpAddressesExample = `
 
 // http://goo.gl/hBc28j
 var DescribeAccountAttributesExample = `
-<DescribeAccountAttributesResponse xmlns="http://ec2.amazonaws.com/doc/2014-02-01/">
+<DescribeAccountAttributesResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
   <accountAttributeSet>
     <item>
@@ -997,7 +1003,7 @@ var DescribeAccountAttributesExample = `
 
 // http://goo.gl/hBc28j
 var DescribeAccountAttributesExample2 = `
-<DescribeAccountAttributesResponse xmlns="http://ec2.amazonaws.com/doc/2014-02-01/">
+<DescribeAccountAttributesResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
   <accountAttributeSet>
     <item>
@@ -1014,7 +1020,7 @@ var DescribeAccountAttributesExample2 = `
 
 // http://goo.gl/hBc28j
 var DescribeAccountAttributesExample3 = `
-<DescribeAccountAttributesResponse xmlns="http://ec2.amazonaws.com/doc/2014-02-01/">
+<DescribeAccountAttributesResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
   <accountAttributeSet>
     <item>

--- a/ec2/subnets.go
+++ b/ec2/subnets.go
@@ -51,7 +51,7 @@ type CreateSubnetResp struct {
 //
 // See http://goo.gl/wLPhfI for more details.
 func (ec2 *EC2) CreateSubnet(vpcId, cidrBlock, availZone string) (resp *CreateSubnetResp, err error) {
-	params := makeParamsVPC("CreateSubnet")
+	params := makeParams("CreateSubnet")
 	params["VpcId"] = vpcId
 	params["CidrBlock"] = cidrBlock
 	if availZone != "" {
@@ -70,7 +70,7 @@ func (ec2 *EC2) CreateSubnet(vpcId, cidrBlock, availZone string) (resp *CreateSu
 //
 // See http://goo.gl/KmhcBM for more details.
 func (ec2 *EC2) DeleteSubnet(id string) (resp *SimpleResp, err error) {
-	params := makeParamsVPC("DeleteSubnet")
+	params := makeParams("DeleteSubnet")
 	params["SubnetId"] = id
 	resp = &SimpleResp{}
 	err = ec2.query(params, resp)
@@ -94,7 +94,7 @@ type SubnetsResp struct {
 //
 // See http://goo.gl/NTKQVI for more details.
 func (ec2 *EC2) Subnets(ids []string, filter *Filter) (resp *SubnetsResp, err error) {
-	params := makeParamsVPC("DescribeSubnets")
+	params := makeParams("DescribeSubnets")
 	for i, id := range ids {
 		params["SubnetId."+strconv.Itoa(i+1)] = id
 	}

--- a/ec2/subnets_test.go
+++ b/ec2/subnets_test.go
@@ -179,6 +179,14 @@ func (s *ServerTests) createSubnet(c *C, vpcId, cidrBlock, availZone string) *ec
 		Total: 2 * time.Minute,
 		Delay: 5 * time.Second,
 	}
+	// Because (as of 2014-10-01) t1.micro and m1.medium instance
+	// types are not available in most us-east-1 availability zones,
+	// except for us-east-1c, we hardcode this here when not set
+	// explicitly in order for those tests using t1.micro/m1.medium to
+	// pass.
+	if availZone == "" {
+		availZone = defaultAvailZone
+	}
 	for a := testAttempt.Start(); a.Next(); {
 		resp, err := s.ec2.CreateSubnet(vpcId, cidrBlock, availZone)
 		if errorCode(err) == "InvalidVpcID.NotFound" {

--- a/ec2/vpc.go
+++ b/ec2/vpc.go
@@ -44,7 +44,7 @@ type CreateVPCResp struct {
 //
 // See http://goo.gl/nkwjvN for more details.
 func (ec2 *EC2) CreateVPC(CIDRBlock, instanceTenancy string) (resp *CreateVPCResp, err error) {
-	params := makeParamsVPC("CreateVpc")
+	params := makeParams("CreateVpc")
 	params["CidrBlock"] = CIDRBlock
 	if instanceTenancy == "" {
 		instanceTenancy = "default"
@@ -66,7 +66,7 @@ func (ec2 *EC2) CreateVPC(CIDRBlock, instanceTenancy string) (resp *CreateVPCRes
 //
 // See http://goo.gl/bcxtbf for more details.
 func (ec2 *EC2) DeleteVPC(id string) (resp *SimpleResp, err error) {
-	params := makeParamsVPC("DeleteVpc")
+	params := makeParams("DeleteVpc")
 	params["VpcId"] = id
 	resp = &SimpleResp{}
 	err = ec2.query(params, resp)
@@ -90,7 +90,7 @@ type VPCsResp struct {
 //
 // See http://goo.gl/Y5kHqG for more details.
 func (ec2 *EC2) VPCs(ids []string, filter *Filter) (resp *VPCsResp, err error) {
-	params := makeParamsVPC("DescribeVpcs")
+	params := makeParams("DescribeVpcs")
 	for i, id := range ids {
 		params["VpcId."+strconv.Itoa(i+1)] = id
 	}


### PR DESCRIPTION
- All EC2 requests now use the latest AWS API version available (2014-10-01).
- ec2test server response types changed as needed to mimic EC2 better (proper response type names and xmlns added, DescribeSecurityGroups response XML fixed to serialized multiple IPPerm.SourceIPs values).
- Changed ec2test responses and tests to match EC2 in a few cases (e.g. InvalidGroup.InUse -> DependencyViolation)
- Removed CreateSecurityGroupVPC() and changed CreateSecurityGroup() to take a VPC ID as first argument (can be empty to create an EC2-Classic SG or a valid VPC ID to create an EC2-VPC SG).
- When debug=true, requests and responses are dumped to the log output. Requests are formatted similarly to the way AWS API docs does).
- Added a few fields to the Instance type - AssociatePublicIP, EBSOptimized, SRIOVNetSupport - available in more recent AWS API versions.
- Improved tests logging and stability when running against live EC2 servers.
