### PR TITLE
ec2, ec2/ec2test: add InstanceBlockDeviceMapping

### DIFF
--- a/ec2/blockdevicemappings_test.go
+++ b/ec2/blockdevicemappings_test.go
@@ -1,0 +1,78 @@
+//
+// goamz - Go packages to interact with the Amazon Web Services.
+//
+//   https://wiki.ubuntu.com/goamz
+//
+// Copyright (c) 2015 Canonical Ltd.
+//
+
+package ec2_test
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v2/ec2"
+)
+
+// Block device mapping tests run against either a local test server or
+// live on EC2.
+
+func (s *ServerTests) TestBlockDeviceMappings(c *C) {
+	blockDeviceMappings := []ec2.BlockDeviceMapping{{
+		DeviceName:          "/dev/sda1",
+		VolumeSize:          8,
+		DeleteOnTermination: true,
+	}, {
+		VirtualName: "ephemeral0",
+		DeviceName:  "/dev/sdb",
+	}}
+
+	instList, err := s.ec2.RunInstances(&ec2.RunInstances{
+		ImageId:             imageId,
+		InstanceType:        "t1.micro",
+		BlockDeviceMappings: blockDeviceMappings,
+	})
+	c.Assert(err, IsNil)
+	inst := instList.Instances[0]
+	c.Assert(inst, NotNil)
+	instId := inst.InstanceId
+	defer terminateInstances(c, s.ec2, []string{instId})
+
+	// Block device mappings are not (typically?) included in the initial
+	// RunInstanceResp, so we must periodically DescribeInstances.
+	testAttempt := aws.AttemptStrategy{
+		Total: 5 * time.Minute,
+		Delay: 5 * time.Second,
+	}
+	var list *ec2.InstancesResp
+	done := false
+	for a := testAttempt.Start(); !done && a.Next(); {
+		c.Logf("waiting for block device mappings to be processed")
+		list, err = s.ec2.Instances([]string{instId}, nil)
+		if err != nil {
+			c.Fatalf("Instances returned: %v", err)
+			return
+		}
+		inst = list.Reservations[0].Instances[0]
+		if len(inst.BlockDeviceMappings) == 0 {
+			c.Logf("BlockDeviceMappings is empty, retrying")
+			continue
+		}
+		done = true
+	}
+	if !done {
+		c.Fatalf("timeout while waiting for block device mappings")
+	}
+
+	// There should be one item for /dev/sda1; ephemeral devices
+	// should not show up.
+	c.Assert(inst.BlockDeviceMappings, HasLen, 1)
+	c.Assert(inst.BlockDeviceMappings[0].DeviceName, Equals, "/dev/sda1")
+	c.Assert(inst.BlockDeviceMappings[0].DeleteOnTermination, Equals, true)
+	c.Assert(inst.BlockDeviceMappings[0].AttachTime, Not(Equals), "")
+	c.Assert(inst.BlockDeviceMappings[0].Status, Not(Equals), "")
+	c.Assert(inst.BlockDeviceMappings[0].VolumeId, Not(Equals), "")
+}

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -282,30 +282,42 @@ type RunInstancesResp struct {
 //
 // See http://goo.gl/OCH8a for more details.
 type Instance struct {
-	InstanceId         string             `xml:"instanceId"`
-	InstanceType       string             `xml:"instanceType"`
-	ImageId            string             `xml:"imageId"`
-	PrivateDNSName     string             `xml:"privateDnsName"`
-	DNSName            string             `xml:"dnsName"`
-	IPAddress          string             `xml:"ipAddress"`
-	PrivateIPAddress   string             `xml:"privateIpAddress"`
-	SubnetId           string             `xml:"subnetId"`
-	VPCId              string             `xml:"vpcId"`
-	SourceDestCheck    bool               `xml:"sourceDestCheck"`
-	KeyName            string             `xml:"keyName"`
-	AMILaunchIndex     int                `xml:"amiLaunchIndex"`
-	Hypervisor         string             `xml:"hypervisor"`
-	VirtType           string             `xml:"virtualizationType"`
-	Monitoring         string             `xml:"monitoring>state"`
-	AvailZone          string             `xml:"placement>availabilityZone"`
-	AssociatePublicIP  bool               `xml:"associatePublicIpAddress,omitempty"`
-	PlacementGroupName string             `xml:"placement>groupName"`
-	EBSOptimized       bool               `xml:"ebsOptimized,omitempty"`
-	SRIOVNetSupport    bool               `xml:"sriovNetSupport,omitempty"`
-	State              InstanceState      `xml:"instanceState"`
-	Tags               []Tag              `xml:"tagSet>item"`
-	SecurityGroups     []SecurityGroup    `xml:"groupSet>item"`
-	NetworkInterfaces  []NetworkInterface `xml:"networkInterfaceSet>item"`
+	InstanceId          string                       `xml:"instanceId"`
+	InstanceType        string                       `xml:"instanceType"`
+	ImageId             string                       `xml:"imageId"`
+	PrivateDNSName      string                       `xml:"privateDnsName"`
+	DNSName             string                       `xml:"dnsName"`
+	IPAddress           string                       `xml:"ipAddress"`
+	PrivateIPAddress    string                       `xml:"privateIpAddress"`
+	SubnetId            string                       `xml:"subnetId"`
+	VPCId               string                       `xml:"vpcId"`
+	SourceDestCheck     bool                         `xml:"sourceDestCheck"`
+	KeyName             string                       `xml:"keyName"`
+	AMILaunchIndex      int                          `xml:"amiLaunchIndex"`
+	Hypervisor          string                       `xml:"hypervisor"`
+	VirtType            string                       `xml:"virtualizationType"`
+	Monitoring          string                       `xml:"monitoring>state"`
+	AvailZone           string                       `xml:"placement>availabilityZone"`
+	AssociatePublicIP   bool                         `xml:"associatePublicIpAddress,omitempty"`
+	PlacementGroupName  string                       `xml:"placement>groupName"`
+	EBSOptimized        bool                         `xml:"ebsOptimized,omitempty"`
+	SRIOVNetSupport     bool                         `xml:"sriovNetSupport,omitempty"`
+	State               InstanceState                `xml:"instanceState"`
+	Tags                []Tag                        `xml:"tagSet>item"`
+	SecurityGroups      []SecurityGroup              `xml:"groupSet>item"`
+	NetworkInterfaces   []NetworkInterface           `xml:"networkInterfaceSet>item"`
+	BlockDeviceMappings []InstanceBlockDeviceMapping `xml:"blockDeviceMapping>item"`
+}
+
+// InstanceBlockDeviceMapping describes a block device mapping.
+//
+// See http://goo.gl/Ua0BIw for more details.
+type InstanceBlockDeviceMapping struct {
+	DeviceName          string `xml:"deviceName"`
+	AttachTime          string `xml:"ebs>attachTime"`
+	DeleteOnTermination bool   `xml:"ebs>deleteOnTermination"`
+	Status              string `xml:"ebs>status"`
+	VolumeId            string `xml:"ebs>volumeId"`
 }
 
 // RunInstances starts new instances in EC2.


### PR DESCRIPTION
This PR introduces the InstanceBlockDeviceMapping data type
and adds the BlockDeviceMappings field to the Instance data
type, enabling users to query instances' block device mappings.

The test server is updated to create volumes for each non-virtual
block device mapping. The volumes are not yet backed by any model,
so attempts to query those resources will fail that is implemented.
