### PR TITLE
Imports changed amz.v2 -> amz.v3-unstable, fixing tests.

### DIFF
--- a/aws/attempt_test.go
+++ b/aws/attempt_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v3-unstable/aws"
 )
 
 func (S) TestAttemptTiming(c *C) {

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -7,7 +7,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v3-unstable/aws"
 )
 
 func Test(t *testing.T) {

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v3-unstable/aws"
 )
 
 const (

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -5,9 +5,9 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/ec2"
-	"gopkg.in/amz.v2/testutil"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/ec2"
+	"gopkg.in/amz.v3-unstable/testutil"
 )
 
 func Test(t *testing.T) {

--- a/ec2/ec2i_test.go
+++ b/ec2/ec2i_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/ec2"
-	"gopkg.in/amz.v2/testutil"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/ec2"
+	"gopkg.in/amz.v3-unstable/testutil"
 )
 
 // AmazonServer represents an Amazon EC2 server.

--- a/ec2/ec2t_test.go
+++ b/ec2/ec2t_test.go
@@ -9,10 +9,10 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/ec2"
-	"gopkg.in/amz.v2/ec2/ec2test"
-	"gopkg.in/amz.v2/testutil"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/ec2"
+	"gopkg.in/amz.v3-unstable/ec2/ec2test"
+	"gopkg.in/amz.v3-unstable/testutil"
 )
 
 // defaultAvailZone is the availability zone to use by default when

--- a/ec2/ec2test/server.go
+++ b/ec2/ec2test/server.go
@@ -18,7 +18,7 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/amz.v2/ec2"
+	"gopkg.in/amz.v3-unstable/ec2"
 )
 
 const defaultXMLName = "http://ec2.amazonaws.com/doc/2014-10-01/"

--- a/ec2/networkinterfaces_test.go
+++ b/ec2/networkinterfaces_test.go
@@ -13,8 +13,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/ec2"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/ec2"
 )
 
 // Network interface tests with example responses

--- a/ec2/privateips_test.go
+++ b/ec2/privateips_test.go
@@ -14,8 +14,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/ec2"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/ec2"
 )
 
 // Private IP tests with example responses

--- a/ec2/subnets_test.go
+++ b/ec2/subnets_test.go
@@ -13,8 +13,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/ec2"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/ec2"
 )
 
 // Subnet tests with example responses

--- a/ec2/vpc_test.go
+++ b/ec2/vpc_test.go
@@ -13,8 +13,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/ec2"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/ec2"
 )
 
 // VPC tests with example responses

--- a/exp/mturk/export_test.go
+++ b/exp/mturk/export_test.go
@@ -1,7 +1,7 @@
 package mturk
 
 import (
-	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v3-unstable/aws"
 )
 
 func Sign(auth aws.Auth, service, method, timestamp string, params map[string]string) {

--- a/exp/mturk/mturk.go
+++ b/exp/mturk/mturk.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"time"
 
-	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v3-unstable/aws"
 )
 
 type MTurk struct {

--- a/exp/mturk/mturk_test.go
+++ b/exp/mturk/mturk_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/exp/mturk"
-	"gopkg.in/amz.v2/testutil"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/exp/mturk"
+	"gopkg.in/amz.v3-unstable/testutil"
 )
 
 func Test(t *testing.T) {

--- a/exp/mturk/sign.go
+++ b/exp/mturk/sign.go
@@ -5,7 +5,7 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 
-	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v3-unstable/aws"
 )
 
 var b64 = base64.StdEncoding

--- a/exp/mturk/sign_test.go
+++ b/exp/mturk/sign_test.go
@@ -3,8 +3,8 @@ package mturk_test
 import (
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/exp/mturk"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/exp/mturk"
 )
 
 // Mechanical Turk REST authentication docs: http://goo.gl/wrzfn

--- a/exp/sdb/export_test.go
+++ b/exp/sdb/export_test.go
@@ -1,7 +1,7 @@
 package sdb
 
 import (
-	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v3-unstable/aws"
 )
 
 func Sign(auth aws.Auth, method, path string, params map[string][]string, headers map[string][]string) {

--- a/exp/sdb/sdb.go
+++ b/exp/sdb/sdb.go
@@ -29,7 +29,7 @@ import (
 	"strconv"
 	"time"
 
-	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v3-unstable/aws"
 )
 
 const debug = false

--- a/exp/sdb/sdb_test.go
+++ b/exp/sdb/sdb_test.go
@@ -5,9 +5,9 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/exp/sdb"
-	"gopkg.in/amz.v2/testutil"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/exp/sdb"
+	"gopkg.in/amz.v3-unstable/testutil"
 )
 
 func Test(t *testing.T) {

--- a/exp/sdb/sign.go
+++ b/exp/sdb/sign.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v3-unstable/aws"
 )
 
 var b64 = base64.StdEncoding

--- a/exp/sdb/sign_test.go
+++ b/exp/sdb/sign_test.go
@@ -3,8 +3,8 @@ package sdb_test
 import (
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/exp/sdb"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/exp/sdb"
 )
 
 // SimpleDB ReST authentication docs: http://goo.gl/CaY81

--- a/exp/sns/sign.go
+++ b/exp/sns/sign.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v3-unstable/aws"
 )
 
 var b64 = base64.StdEncoding

--- a/exp/sns/sns.go
+++ b/exp/sns/sns.go
@@ -32,7 +32,7 @@ import (
 	"strconv"
 	"time"
 
-	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v3-unstable/aws"
 )
 
 // The SNS type encapsulates operation with an SNS region.

--- a/exp/sns/sns_test.go
+++ b/exp/sns/sns_test.go
@@ -5,9 +5,9 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/exp/sns"
-	"gopkg.in/amz.v2/testutil"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/exp/sns"
+	"gopkg.in/amz.v3-unstable/testutil"
 )
 
 func Test(t *testing.T) {

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v3-unstable/aws"
 )
 
 // The IAM type encapsulates operations operations with the IAM endpoint.

--- a/iam/iam_test.go
+++ b/iam/iam_test.go
@@ -6,9 +6,9 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/iam"
-	"gopkg.in/amz.v2/testutil"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/iam"
+	"gopkg.in/amz.v3-unstable/testutil"
 )
 
 func Test(t *testing.T) {

--- a/iam/iami_test.go
+++ b/iam/iami_test.go
@@ -5,9 +5,9 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/iam"
-	"gopkg.in/amz.v2/testutil"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/iam"
+	"gopkg.in/amz.v3-unstable/testutil"
 )
 
 // AmazonServer represents an Amazon AWS server.

--- a/iam/iamt_test.go
+++ b/iam/iamt_test.go
@@ -3,9 +3,9 @@ package iam_test
 import (
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/iam"
-	"gopkg.in/amz.v2/iam/iamtest"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/iam"
+	"gopkg.in/amz.v3-unstable/iam/iamtest"
 )
 
 // LocalServer represents a local ec2test fake server.

--- a/iam/iamtest/server.go
+++ b/iam/iamtest/server.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"sync"
 
-	"gopkg.in/amz.v2/iam"
+	"gopkg.in/amz.v3-unstable/iam"
 )
 
 type action struct {

--- a/iam/sign.go
+++ b/iam/sign.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v3-unstable/aws"
 )
 
 // ----------------------------------------------------------------------------

--- a/s3/export_test.go
+++ b/s3/export_test.go
@@ -1,7 +1,7 @@
 package s3
 
 import (
-	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v3-unstable/aws"
 )
 
 var originalStrategy = attempts

--- a/s3/multi_test.go
+++ b/s3/multi_test.go
@@ -8,7 +8,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/s3"
+	"gopkg.in/amz.v3-unstable/s3"
 )
 
 func (s *S) TestInitMulti(c *C) {

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v3-unstable/aws"
 )
 
 const debug = false

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -9,9 +9,9 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/s3"
-	"gopkg.in/amz.v2/testutil"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/s3"
+	"gopkg.in/amz.v3-unstable/testutil"
 )
 
 func Test(t *testing.T) {

--- a/s3/s3i_test.go
+++ b/s3/s3i_test.go
@@ -13,9 +13,9 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/s3"
-	"gopkg.in/amz.v2/testutil"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/s3"
+	"gopkg.in/amz.v3-unstable/testutil"
 )
 
 // AmazonServer represents an Amazon S3 server.

--- a/s3/s3t_test.go
+++ b/s3/s3t_test.go
@@ -3,9 +3,9 @@ package s3_test
 import (
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/s3"
-	"gopkg.in/amz.v2/s3/s3test"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/s3"
+	"gopkg.in/amz.v3-unstable/s3/s3test"
 )
 
 type LocalServer struct {

--- a/s3/s3test/server.go
+++ b/s3/s3test/server.go
@@ -19,7 +19,7 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/amz.v2/s3"
+	"gopkg.in/amz.v3-unstable/s3"
 )
 
 const debug = false

--- a/s3/sign.go
+++ b/s3/sign.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v3-unstable/aws"
 )
 
 var b64 = base64.StdEncoding

--- a/s3/sign_test.go
+++ b/s3/sign_test.go
@@ -3,8 +3,8 @@ package s3_test
 import (
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
-	"gopkg.in/amz.v2/s3"
+	"gopkg.in/amz.v3-unstable/aws"
+	"gopkg.in/amz.v3-unstable/s3"
 )
 
 // S3 ReST authentication docs: http://goo.gl/G1LrK

--- a/testutil/suite.go
+++ b/testutil/suite.go
@@ -5,7 +5,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"gopkg.in/amz.v2/aws"
+	"gopkg.in/amz.v3-unstable/aws"
 )
 
 // Amazon must be used by all tested packages to determine whether to


### PR DESCRIPTION
Just mechanical search/replace of the import paths, using:

```
$ govers -d gopkg.in/amz.v3-unstable
```
