### PR TITLE
Backport flaky test fix for go 1.4 from v2

### DIFF
--- a/ec2/ec2t_test.go
+++ b/ec2/ec2t_test.go
@@ -527,6 +527,7 @@ func (s *ServerTests) TestIPPerms(c *C) {
 			// Only source IPs should exist.
 			c.Check(sourceGroups, IsNil)
 			c.Check(sourceIPs, HasLen, 2)
+			sort.Strings(sourceIPs)
 			c.Check(sourceIPs, DeepEquals, []string{"127.0.0.0/24", "200.1.1.34/32"})
 		}
 		c.Check(ipperm.Protocol, Equals, "tcp")


### PR DESCRIPTION
Just a single line fix for TestIPPerms, which fails under CI more frequently for go 1.4.

This time with correct base branch.
