### PR TITLE
add CacheControl metadata option

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -184,18 +184,19 @@ func (b *Bucket) GetReader(path string) (rc io.ReadCloser, err error) {
 // Put inserts an object into the S3 bucket.
 //
 // See http://goo.gl/FEBPD for details.
-func (b *Bucket) Put(path string, data []byte, contType string, perm ACL) error {
+func (b *Bucket) Put(path string, data []byte, contType string, perm ACL, cacheControl string) error {
 	body := bytes.NewBuffer(data)
-	return b.PutReader(path, body, int64(len(data)), contType, perm)
+	return b.PutReader(path, body, int64(len(data)), contType, perm, cacheControl)
 }
 
 // PutReader inserts an object into the S3 bucket by consuming data
 // from r until EOF.
-func (b *Bucket) PutReader(path string, r io.Reader, length int64, contType string, perm ACL) error {
+func (b *Bucket) PutReader(path string, r io.Reader, length int64, contType string, perm ACL, cacheControl string) error {
 	headers := map[string][]string{
 		"Content-Length": {strconv.FormatInt(length, 10)},
 		"Content-Type":   {contType},
 		"x-amz-acl":      {string(perm)},
+		"Cache-Control":  {cacheControl},
 	}
 	req := &request{
 		method:  "PUT",


### PR DESCRIPTION
Cache-Control is a critical metadata option when uploading files to S3, without it Amazon Cloudfront will not cache objects from an S3 bucket source. In addition, after the resource has been uploaded to S3, there is no programmatic way of changing the Cache-Control metadata tag, so it is most desirable to do this when you first upload. 
