### PR TITLE
Migrated v4 signing process to streaming.

### DIFF
--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -191,7 +191,7 @@ func (s *S) TestPutReader(c *C) {
 
 	b, err := s.s3.Bucket("bucket")
 	c.Assert(err, IsNil)
-	buf := bytes.NewBufferString("content")
+	buf := bytes.NewReader([]byte("content"))
 	err = b.PutReader("name", buf, int64(buf.Len()), "content-type", s3.Private)
 	c.Assert(err, IsNil)
 
@@ -210,7 +210,7 @@ func (s *S) TestPutReaderWithHeader(c *C) {
 
 	b, err := s.s3.Bucket("bucket")
 	c.Assert(err, IsNil)
-	buf := bytes.NewBufferString("content")
+	buf := bytes.NewReader([]byte("content"))
 	err = b.PutReaderWithHeader("name", buf, int64(buf.Len()), "content-type", s3.Private, http.Header{
 		"Cache-Control": []string{"max-age=5"},
 	})

--- a/s3/s3i_test.go
+++ b/s3/s3i_test.go
@@ -198,7 +198,7 @@ func (s *ClientTests) TestBasicFunctionality(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(string(data), Equals, "yo!")
 
-	buf := bytes.NewBufferString("hey!")
+	buf := bytes.NewReader([]byte("hey!"))
 	err = b.PutReader("name2", buf, int64(buf.Len()), "text/plain", s3.Private)
 	c.Assert(err, IsNil)
 	defer b.Del("name2")


### PR DESCRIPTION
- Migrated v4 signing process to streaming. This limits the amount of data that needs to be stored in memory during the signing process.
