### PR TITLE
Return the correct error codes for volume related errors

### DIFF
--- a/ec2/ec2t_test.go
+++ b/ec2/ec2t_test.go
@@ -70,6 +70,11 @@ func (s *LocalServerSuite) TestSecurityGroups(c *C) {
 	s.clientTests.TestSecurityGroups(c)
 }
 
+func (s *LocalServerSuite) TestVolumeAttachments(c *C) {
+	s.srv.srv.SetInitialInstanceState(ec2test.Running)
+	s.ServerTests.testVolumeAttachments(c)
+}
+
 // TestUserData is not defined on ServerTests because it
 // requires the ec2test server to function.
 func (s *LocalServerSuite) TestUserData(c *C) {
@@ -891,6 +896,10 @@ func (s *AmazonServerSuite) TestRunInstancesVPC(c *C) {
 	c.Check(newNIC.Attachment.Status, Matches, `^(attaching|attached)$`)
 	c.Check(newNIC.Attachment.DeviceIndex, Equals, 0)
 	c.Check(newNIC.Attachment.DeleteOnTermination, Equals, true)
+}
+
+func (s *AmazonServerSuite) TestVolumeAttachments(c *C) {
+	s.ServerTests.testVolumeAttachments(c)
 }
 
 func idsOnly(gs []ec2.SecurityGroup) []ec2.SecurityGroup {


### PR DESCRIPTION
Not all of the AWS error codes were being correctly returned by the test server.
Fix these also meant that the volume attachments test had to be moved, so that when run locally, fake instance status could be set.

Tested live.
