### PR TITLE
LICENSE updated to provide 'default' copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+Copyright (C) 2011-2015 Canonical Ltd.
 This software is licensed under the LGPLv3, included below.
 
 As a special exception to the GNU Lesser General Public License version 3


### PR DESCRIPTION
Some files in the repo don't have copyright notice provided.
We may deal with it by providing 'default' copyright which points to the main contributor (Canonical).
Files created by other authors (AppsAttic Ltd., Memeo Inc.) have explicit copyright notice inside.
