### PR TITLE
Signing fixes & error handling.

### DIFF
--- a/aws/sign_test.go
+++ b/aws/sign_test.go
@@ -139,7 +139,7 @@ func (s *SigningSuite) TestV4MoreCompleteSignature(c *C) {
 	}
 	err = SignV4(req, testAuth, USEast.Name, "s3")
 	c.Assert(err, IsNil)
-	c.Check(req.Header.Get("Authorization"), Equals, "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41")
+	c.Check(req.Header.Get("Authorization"), Equals, "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;range;x-amz-content-sha256;x-amz-date, Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41")
 }
 
 //

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -142,8 +142,11 @@ func (ec2 *EC2) query(params map[string]string, resp interface{}) error {
 	}
 	query.Add("Timestamp", timeNow().In(time.UTC).Format(time.RFC3339))
 	req.URL.RawQuery = query.Encode()
+	req.Header.Set("x-amz-date", time.Now().In(time.UTC).Format(aws.ISO8601BasicFormat))
 
-	ec2.Sign(req, ec2.Auth)
+	if err := ec2.Sign(req, ec2.Auth); err != nil {
+		return err
+	}
 
 	r, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/ec2/ec2i_test.go
+++ b/ec2/ec2i_test.go
@@ -151,6 +151,14 @@ func (s *ClientTests) TestSecurityGroups(c *C) {
 	c.Assert(resp2.RequestId, Matches, ".+")
 }
 
+func (s *ClientTests) TestDescribeAccountAttributes(c *C) {
+
+	ec2 := ec2.New(s.ec2.Auth, aws.USEast, aws.SignV4Factory(aws.USEast.Name, "ec2"))
+	resp, err := ec2.AccountAttributes("supported-platforms")
+	c.Assert(err, IsNil)
+	c.Assert(resp, NotNil)
+}
+
 var sessionId = func() string {
 	buf := make([]byte, 8)
 	// if we have no randomness, we'll just make do, so ignore the error.


### PR DESCRIPTION
- EC2 queries now properly return errors from the signing process should they occur.
- The v4 signing process now uses a "/" for the request path if no path is present.
- Added test for describe-account-attributes, which was failing with v4 signing.

Live S3 testing done to ensure no breakages.
