### PR TITLE
Add NextMarker to support paging

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -292,11 +292,12 @@ func (b *Bucket) Del(path string) error {
 
 // The ListResp type holds the results of a List bucket operation.
 type ListResp struct {
-	Name      string
-	Prefix    string
-	Delimiter string
-	Marker    string
-	MaxKeys   int
+	Name       string
+	Prefix     string
+	Delimiter  string
+	Marker     string
+	NextMarker string
+	MaxKeys    int
 	// IsTruncated is true if the results have been truncated because
 	// there are more keys and prefixes than can fit in MaxKeys.
 	// N.B. this is the opposite sense to that documented (incorrectly) in


### PR DESCRIPTION
According to latest s3 doc, use NextMarker to support fetch next page of results (http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html)
