### PR TITLE
Update EC2 environment variable

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -211,12 +211,18 @@ func init() {
 
 // EnvAuth creates an Auth based on environment information.
 // The AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment
-// variables are used as the first preference, but AWS_ACCESS_KEY
-// and AWS_SECRET_KEY environment variables are also supported.
+// variables are used as the first preference, but EC2_ACCESS_KEY
+// and EC2_SECRET_KEY or AWS_ACCESS_KEY and AWS_SECRET_KEY
+// environment variables are also supported.
 func EnvAuth() (auth Auth, err error) {
 	auth.AccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
 	auth.SecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
-	// We fallback to AWS_ env variables if the AWS_ variants are not used.
+	// first fallbaback to EC2_ env variable
+	if auth.AccessKey == "" && auth.SecretKey == "" {
+		auth.AccessKey = os.Getenv("EC2_ACCESS_KEY")
+		auth.SecretKey = os.Getenv("EC2_SECRET_KEY")
+	}
+	// second fallbaback to AWS_ env variable
 	if auth.AccessKey == "" && auth.SecretKey == "" {
 		auth.AccessKey = os.Getenv("AWS_ACCESS_KEY")
 		auth.SecretKey = os.Getenv("AWS_SECRET_KEY")

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -211,12 +211,12 @@ func init() {
 
 // EnvAuth creates an Auth based on environment information.
 // The AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment
-// variables are used as the first preference, but EC2_ACCESS_KEY
-// and EC2_SECRET_KEY environment variables are also supported.
+// variables are used as the first preference, but AWS_ACCESS_KEY
+// and AWS_SECRET_KEY environment variables are also supported.
 func EnvAuth() (auth Auth, err error) {
 	auth.AccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
 	auth.SecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
-	// We fallback to EC2_ env variables if the AWS_ variants are not used.
+	// We fallback to AWS_ env variables if the AWS_ variants are not used.
 	if auth.AccessKey == "" && auth.SecretKey == "" {
 		auth.AccessKey = os.Getenv("AWS_ACCESS_KEY")
 		auth.SecretKey = os.Getenv("AWS_SECRET_KEY")

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -218,8 +218,8 @@ func EnvAuth() (auth Auth, err error) {
 	auth.SecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
 	// We fallback to EC2_ env variables if the AWS_ variants are not used.
 	if auth.AccessKey == "" && auth.SecretKey == "" {
-		auth.AccessKey = os.Getenv("EC2_ACCESS_KEY")
-		auth.SecretKey = os.Getenv("EC2_SECRET_KEY")
+		auth.AccessKey = os.Getenv("AWS_ACCESS_KEY")
+		auth.SecretKey = os.Getenv("AWS_SECRET_KEY")
 	}
 	if auth.AccessKey == "" {
 		err = errors.New("AWS_ACCESS_KEY_ID not found in environment")

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -56,6 +56,15 @@ func (s *S) TestEnvAuth(c *C) {
 
 func (s *S) TestEnvAuthLegacy(c *C) {
 	os.Clearenv()
+	os.Setenv("EC2_SECRET_KEY", "secret")
+	os.Setenv("EC2_ACCESS_KEY", "access")
+	auth, err := aws.EnvAuth()
+	c.Assert(err, IsNil)
+	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access"})
+}
+
+func (s *S) TestEnvAuthAws(c *C) {
+	os.Clearenv()
 	os.Setenv("AWS_SECRET_KEY", "secret")
 	os.Setenv("AWS_ACCESS_KEY", "access")
 	auth, err := aws.EnvAuth()

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -56,8 +56,8 @@ func (s *S) TestEnvAuth(c *C) {
 
 func (s *S) TestEnvAuthLegacy(c *C) {
 	os.Clearenv()
-	os.Setenv("EC2_SECRET_KEY", "secret")
-	os.Setenv("EC2_ACCESS_KEY", "access")
+	os.Setenv("AWS_SECRET_KEY", "secret")
+	os.Setenv("AWS_ACCESS_KEY", "access")
 	auth, err := aws.EnvAuth()
 	c.Assert(err, IsNil)
 	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access"})


### PR DESCRIPTION
I think the EC2 environment has updated from AWS_\* to EC2_*

http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/ApiReference-cmd-CreateVolume.html
