### PR TITLE
ec2: add Instance.RootDevice{Type,Name}

### DIFF
--- a/ec2/blockdevicemappings_test.go
+++ b/ec2/blockdevicemappings_test.go
@@ -22,7 +22,7 @@ import (
 
 func (s *ServerTests) TestBlockDeviceMappings(c *C) {
 	blockDeviceMappings := []ec2.BlockDeviceMapping{{
-		DeviceName:          "/dev/sda1",
+		DeviceName:          "/dev/sda2",
 		VolumeSize:          8,
 		DeleteOnTermination: true,
 	}, {
@@ -69,10 +69,15 @@ func (s *ServerTests) TestBlockDeviceMappings(c *C) {
 
 	// There should be one item for /dev/sda1; ephemeral devices
 	// should not show up.
-	c.Assert(inst.BlockDeviceMappings, HasLen, 1)
+	c.Assert(inst.BlockDeviceMappings, HasLen, 2)
 	c.Assert(inst.BlockDeviceMappings[0].DeviceName, Equals, "/dev/sda1")
 	c.Assert(inst.BlockDeviceMappings[0].DeleteOnTermination, Equals, true)
 	c.Assert(inst.BlockDeviceMappings[0].AttachTime, Not(Equals), "")
 	c.Assert(inst.BlockDeviceMappings[0].Status, Not(Equals), "")
 	c.Assert(inst.BlockDeviceMappings[0].VolumeId, Not(Equals), "")
+	c.Assert(inst.BlockDeviceMappings[1].DeviceName, Equals, "/dev/sda2")
+	c.Assert(inst.BlockDeviceMappings[1].DeleteOnTermination, Equals, true)
+	c.Assert(inst.BlockDeviceMappings[1].AttachTime, Not(Equals), "")
+	c.Assert(inst.BlockDeviceMappings[1].Status, Not(Equals), "")
+	c.Assert(inst.BlockDeviceMappings[1].VolumeId, Not(Equals), "")
 }

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -312,6 +312,8 @@ type Instance struct {
 	SecurityGroups      []SecurityGroup              `xml:"groupSet>item"`
 	NetworkInterfaces   []NetworkInterface           `xml:"networkInterfaceSet>item"`
 	BlockDeviceMappings []InstanceBlockDeviceMapping `xml:"blockDeviceMapping>item"`
+	RootDeviceType      string                       `xml:"rootDeviceType"`
+	RootDeviceName      string                       `xml:"rootDeviceName"`
 }
 
 // InstanceBlockDeviceMapping describes a block device mapping.

--- a/ec2/ec2t_test.go
+++ b/ec2/ec2t_test.go
@@ -32,6 +32,7 @@ func (s *LocalServer) SetUp(c *C) {
 	srv, err := ec2test.NewServer()
 	c.Assert(err, IsNil)
 	c.Assert(srv, NotNil)
+	srv.SetCreateRootDisks(true)
 
 	// Add default attributes.
 	srv.SetInitialAttributes(map[string][]string{


### PR DESCRIPTION
Add the titular fields, as well as an optional
mode for the ec2test server which causes it to
create root disks for instances. We don't do
this by default because the automatically added
volumes can make tests unclear.
