### PR TITLE
Make counter thread safe

### DIFF
--- a/ec2/ec2test/network_interfaces.go
+++ b/ec2/ec2test/network_interfaces.go
@@ -280,11 +280,11 @@ func (srv *Server) createNICsOnRun(instId string, instSubnet *subnet, ifacesToCr
 	var createdNICs []ec2.NetworkInterface
 	for _, ifaceToCreate := range ifacesToCreate {
 		nicId := ifaceToCreate.Id
-		macAddress := fmt.Sprintf("20:%02x:60:cb:27:37", srv.ifaceId)
+		macAddress := fmt.Sprintf("20:%02x:60:cb:27:37", srv.ifaceId.get())
 		if nicId == "" {
 			// Simulate a NIC got created.
 			nicId = fmt.Sprintf("eni-%d", srv.ifaceId.next())
-			macAddress = fmt.Sprintf("20:%02x:60:cb:27:37", srv.ifaceId)
+			macAddress = fmt.Sprintf("20:%02x:60:cb:27:37", srv.ifaceId.get())
 		}
 		groups := make([]ec2.SecurityGroup, len(ifaceToCreate.SecurityGroupIds))
 		for i, sgId := range ifaceToCreate.SecurityGroupIds {
@@ -398,7 +398,7 @@ func (srv *Server) createIFace(w http.ResponseWriter, req *http.Request, reqId s
 		Description:      desc,
 		OwnerId:          ownerId,
 		Status:           "available",
-		MACAddress:       fmt.Sprintf("20:%02x:60:cb:27:37", srv.ifaceId),
+		MACAddress:       fmt.Sprintf("20:%02x:60:cb:27:37", srv.ifaceId.get()),
 		PrivateIPAddress: primaryIP,
 		PrivateDNSName:   srv.dnsNameFromPrivateIP(primaryIP),
 		SourceDestCheck:  true,

--- a/ec2/ec2test/server.go
+++ b/ec2/ec2test/server.go
@@ -89,19 +89,19 @@ func (srv *Server) Reset(withoutZonesOrGroups bool) {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
 
-	srv.maxId = 0
-	srv.reqId = 0
-	srv.reservationId = 0
-	srv.groupId = 0
-	srv.vpcId = 0
-	srv.igwId = 0
-	srv.rtbId = 0
-	srv.rtbassocId = 0
-	srv.dhcpOptsId = 0
-	srv.subnetId = 0
-	srv.volumeId = 0
-	srv.ifaceId = 0
-	srv.attachId = 0
+	srv.maxId.reset()
+	srv.reqId.reset()
+	srv.reservationId.reset()
+	srv.groupId.reset()
+	srv.vpcId.reset()
+	srv.igwId.reset()
+	srv.rtbId.reset()
+	srv.rtbassocId.reset()
+	srv.dhcpOptsId.reset()
+	srv.subnetId.reset()
+	srv.volumeId.reset()
+	srv.ifaceId.reset()
+	srv.attachId.reset()
 
 	srv.attributes = make(map[string][]string)
 	srv.instances = make(map[string]*Instance)


### PR DESCRIPTION
ect/ec2test/helper.go counter was not being used in a thread safe manner, so now it is a struct with next, get and reset functions. The old next function just incremented an integer and returned the old value. Now accessing by next, get and reset are all atomic.
