### PR TITLE
Add tag support to instances

### DIFF
--- a/ec2/ec2test/instances.go
+++ b/ec2/ec2test/instances.go
@@ -158,7 +158,7 @@ func (inst *Instance) ec2instance() ec2.Instance {
 }
 
 func (inst *Instance) matchAttr(attr, value string) (ok bool, err error) {
-	if strings.HasPrefix(attr, "tag.") && len(attr) > 4 {
+	if strings.HasPrefix(attr, "tag:") && len(attr) > 4 {
 		filterTag := attr[4:]
 		for _, t := range inst.tags {
 			if filterTag == t.Key && t.Value == value {

--- a/ec2/ec2test/instances.go
+++ b/ec2/ec2test/instances.go
@@ -158,6 +158,15 @@ func (inst *Instance) ec2instance() ec2.Instance {
 }
 
 func (inst *Instance) matchAttr(attr, value string) (ok bool, err error) {
+	if strings.HasPrefix(attr, "tag.") && len(attr) > 4 {
+		filterTag := attr[4:]
+		for _, t := range inst.tags {
+			if filterTag == t.Key && t.Value == value {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
 	switch attr {
 	case "architecture":
 		return value == "i386", nil


### PR DESCRIPTION
goamz supports filtering by tag by adding a filter with a key
prefixed by "tag." I added this behavior to the current
instance implementation in ec2test.
