### PR TITLE
ec2test: handle security group tags

### DIFF
--- a/ec2/ec2test/instances.go
+++ b/ec2/ec2test/instances.go
@@ -160,12 +160,7 @@ func (inst *Instance) ec2instance() ec2.Instance {
 func (inst *Instance) matchAttr(attr, value string) (ok bool, err error) {
 	if strings.HasPrefix(attr, "tag:") && len(attr) > 4 {
 		filterTag := attr[4:]
-		for _, t := range inst.tags {
-			if filterTag == t.Key && t.Value == value {
-				return true, nil
-			}
-		}
-		return false, nil
+		return matchTag(inst.tags, filterTag, value), nil
 	}
 	switch attr {
 	case "architecture":

--- a/ec2/ec2test/reservations.go
+++ b/ec2/ec2test/reservations.go
@@ -32,7 +32,14 @@ func (srv *Server) newReservation(groups []*securityGroup) *reservation {
 
 func (r *reservation) hasRunningMachine() bool {
 	for _, inst := range r.instances {
-		if inst.state.Code != ShuttingDown.Code && inst.state.Code != Terminated.Code {
+		if inst.state == ShuttingDown {
+			// The instance is shutting down: tell the client that
+			// it's still running, but transition it to terminated
+			// so another query will not find it running.
+			inst.state = Terminated
+			return true
+		}
+		if inst.state != Terminated {
 			return true
 		}
 	}

--- a/ec2/ec2test/securty_groups.go
+++ b/ec2/ec2test/securty_groups.go
@@ -33,6 +33,7 @@ type securityGroup struct {
 	vpcId       string
 
 	perms map[permKey]bool
+	tags  []ec2.Tag
 }
 
 // securityGroupInfo is almost the same as ec2.SecurityGroupInfo, but
@@ -130,6 +131,10 @@ func (g *securityGroup) matchAttr(attr, value string) (ok bool, err error) {
 		return value == ownerId, nil
 	case "vpc-id":
 		return g.vpcId == value, nil
+	}
+	if strings.HasPrefix(attr, "tag:") {
+		key := attr[len("tag:"):]
+		return matchTag(g.tags, key, value), nil
 	}
 	return false, fmt.Errorf("unknown attribute %q", attr)
 }

--- a/ec2/ec2test/tags.go
+++ b/ec2/ec2test/tags.go
@@ -98,6 +98,10 @@ func (srv *Server) tags(id string) *[]ec2.Tag {
 		if inst, ok := srv.instances[id]; ok {
 			return &inst.tags
 		}
+	case "sg":
+		if group, ok := srv.groups[id]; ok {
+			return &group.tags
+		}
 	case "vol":
 		if vol, ok := srv.volumes[id]; ok {
 			return &vol.Tags


### PR DESCRIPTION
Update CreateTags and security group filtering to handle tags.

Also update "reservation.hasRunningMachine" to perform
the same advance-from-shuttingdown-to-terminated logic
that is applied in "DescribeInstances". This is necessary
to avoid DependencyViolation errors when running the
tests in Juju.
