### PR TITLE
Force requestTime to use UTC

### DIFF
--- a/aws/sign.go
+++ b/aws/sign.go
@@ -422,7 +422,8 @@ func requestTime(req *http.Request) (time.Time, error) {
 
 	// Start attempting to parse
 	for _, format := range timeFormats {
-		if parsedTime, err := time.Parse(format, date); err == nil {
+		// Use ParseInLocation to avoid tz mis-calculations, as seen with DST.
+		if parsedTime, err := time.ParseInLocation(format, date, time.FixedZone("UTC", 0)); err == nil {
 			return parsedTime, nil
 		}
 	}


### PR DESCRIPTION
`requestTime()` was using time.Parse, which tries to use the client
location as timezone. This was seen to be confused by daylight savings
time on a client in GMT. This change uses time.ParseInLocation to force
UTC in all cases.

QA test:
 * Without this change, use `dpkg-reconfigure tzdata` to set your client to a GMT timezone (Dublin or Belfast, for example)
   - Tests should fail for the HTTP date headers being out by one hour
   - In a non-GMT timezone, they should pass.
 * With this change, the above tests should all pass