### PR TITLE
Add association field for private IPs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ sudo: false
 language: go
 
 go:
-  - 1.2
-  - 1.4
+  - "1.10"
 
 install:
  - go get gopkg.in/check.v1

--- a/aws/sign.go
+++ b/aws/sign.go
@@ -18,7 +18,8 @@ import (
 
 var debug = log.New(
 	// Remove the c-style comment header to front of line to debug information.
-	/*os.Stdout, //*/ ioutil.Discard,
+	/*os.Stdout, //*/
+	ioutil.Discard,
 	"DEBUG: ",
 	log.LstdFlags,
 )

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -32,7 +32,7 @@ const (
 	debug = false
 
 	// apiVersion is the AWS API version used for all EC2 requests.
-	apiVersion = "2014-10-01"
+	apiVersion = "2015-03-01"
 )
 
 // The EC2 type encapsulates operations with a specific EC2 region.

--- a/ec2/ec2test/network_interfaces.go
+++ b/ec2/ec2test/network_interfaces.go
@@ -255,8 +255,9 @@ func (srv *Server) addDefaultNIC(instSubnet *subnet) []ec2.RunNetworkInterface {
 	if !ipnet.Contains(ip) {
 		panic(fmt.Sprintf("%q does not contain IP %q", instSubnet.Id, ip))
 	}
+	ifID := srv.ifaceId.next()
 	return []ec2.RunNetworkInterface{{
-		Id:                  fmt.Sprintf("eni-%d", srv.ifaceId.next()),
+		Id:                  fmt.Sprintf("eni-%d", ifID),
 		DeviceIndex:         0,
 		Description:         "created by ec2test server",
 		DeleteOnTermination: true,
@@ -264,6 +265,12 @@ func (srv *Server) addDefaultNIC(instSubnet *subnet) []ec2.RunNetworkInterface {
 			Address:   ip.String(),
 			DNSName:   srv.dnsNameFromPrivateIP(ip.String()),
 			IsPrimary: true,
+			// Assign a public shadow IP
+			Association: ec2.IPAssociation{
+				PublicIP:      fmt.Sprintf("73.37.0.%d", ifID+1),
+				PublicDNSName: fmt.Sprintf("ec2-73-37-0-%d.compute-1.amazonaws.com", ifID+1),
+				IPOwnerId:     "amazon",
+			},
 		}},
 	}}
 }

--- a/ec2/ec2test/volume_attachments.go
+++ b/ec2/ec2test/volume_attachments.go
@@ -72,7 +72,7 @@ func (srv *Server) parseVolumeAttachment(req *http.Request) ec2.VolumeAttachment
 			// Check volume id validity.
 			vol = srv.volume(v)
 			if vol.Status != "available" {
-				fatalf(400, " IncorrectState", "cannot attach volume that is not available", v)
+				fatalf(400, " IncorrectState", "cannot attach volume that is not available: %v", v)
 			}
 			attachment.VolumeId = v
 		case "InstanceId":

--- a/ec2/ec2test/vpcs_test.go
+++ b/ec2/ec2test/vpcs_test.go
@@ -11,6 +11,7 @@ package ec2test_test
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -70,6 +71,9 @@ func (s *S) TestAddVPC(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(resp, NotNil)
 	c.Assert(resp.VPCs, HasLen, 2) // default and the one just added.
+	sort.Slice(resp.VPCs, func(l, r int) bool {
+		return resp.VPCs[l].CIDRBlock > resp.VPCs[r].CIDRBlock
+	})
 	c.Assert(resp.VPCs[0].IsDefault, Equals, true)
 	c.Assert(resp.VPCs[1], DeepEquals, added)
 }

--- a/ec2/networkinterfaces.go
+++ b/ec2/networkinterfaces.go
@@ -27,13 +27,22 @@ type NetworkInterfaceAttachment struct {
 	DeleteOnTermination bool   `xml:"deleteOnTermination"`
 }
 
+// IPAssociation describes association information for an Elastic IP address.
+// See http://goo.gl/YCDdMe for more details
+type IPAssociation struct {
+	PublicIP      string `xml:"publicIp"`
+	PublicDNSName string `xml:"publicDnsName"`
+	IPOwnerId     string `xml:"ipOwnerId"`
+}
+
 // PrivateIP describes a private IP address of a network interface.
 //
 // See http://goo.gl/jtuQEJ for more details.
 type PrivateIP struct {
-	Address   string `xml:"privateIpAddress"`
-	DNSName   string `xml:"privateDnsName"`
-	IsPrimary bool   `xml:"primary"`
+	Address     string        `xml:"privateIpAddress"`
+	DNSName     string        `xml:"privateDnsName"`
+	IsPrimary   bool          `xml:"primary"`
+	Association IPAssociation `xml:"association"`
 }
 
 // NetworkInterface describes a network interface for VPC.

--- a/ec2/networkinterfaces_test.go
+++ b/ec2/networkinterfaces_test.go
@@ -154,7 +154,15 @@ func (s *S) TestNetworkInterfacesExample(c *C) {
 		DeleteOnTermination: true,
 	})
 	c.Check(iface.PrivateIPs, DeepEquals, []ec2.PrivateIP{
-		{Address: "10.0.1.233", IsPrimary: true},
+		{
+			Address:   "10.0.1.233",
+			IsPrimary: true,
+			Association: ec2.IPAssociation{
+				PublicIP:      "52.71.251.91",
+				PublicDNSName: "ec2-52-71-251-91.compute-1.amazonaws.com",
+				IPOwnerId:     "amazon",
+			},
+		},
 		{Address: "10.0.1.20", IsPrimary: false},
 	})
 	c.Check(iface.Tags, HasLen, 0)

--- a/ec2/responses_test.go
+++ b/ec2/responses_test.go
@@ -953,6 +953,11 @@ var DescribeNetworkInterfacesExample = `
            <item>
              <privateIpAddress>10.0.1.233</privateIpAddress>
              <primary>true</primary>
+             <association>
+               <ipOwnerId>amazon</ipOwnerId>
+               <publicDnsName>ec2-52-71-251-91.compute-1.amazonaws.com</publicDnsName>
+               <publicIp>52.71.251.91</publicIp>
+             </association>
            </item>
            <item>
              <privateIpAddress>10.0.1.20</privateIpAddress>

--- a/s3/multi_test.go
+++ b/s3/multi_test.go
@@ -245,7 +245,9 @@ func (s *S) TestPutAllZeroSizeFile(c *C) {
 	c.Assert(req.Method, Equals, "PUT")
 	c.Assert(req.URL.Path, Equals, "/sample/multi")
 	c.Assert(req.Form["partNumber"], DeepEquals, []string{"1"})
-	c.Assert(req.Header["Content-Length"], DeepEquals, []string{"0"})
+	if contentLength := req.Header.Get("Content-Length"); contentLength != "" {
+		c.Assert(contentLength, DeepEquals, []string{"0"})
+	}
 	c.Assert(readAll(req.Body), Equals, "")
 }
 

--- a/s3/s3i_test.go
+++ b/s3/s3i_test.go
@@ -501,7 +501,7 @@ func (s *ClientTests) TestMultiComplete(c *C) {
 	c.Assert(len(data), Equals, len(data1)+len(data2))
 	for i := range data1 {
 		if data[i] != data1[i] {
-			c.Fatalf("uploaded object at byte %d: want %d, got %d", data1[i], data[i])
+			c.Fatalf("uploaded object at byte %d: want %d, got %d", i, data1[i], data[i])
 		}
 	}
 	c.Assert(string(data[len(data1):]), Equals, string(data2))


### PR DESCRIPTION
This PR introduces support for IP associations to the `PrivateIP` type (see: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_NetworkInterfacePrivateIpAddress.html). Currently, the code was using the `2014-10-01` version of the API which does not return IP association information when querying interfaces. The PR bumps it to the next version (`2015-03-01`) which does. I did run the integration test-suite which while flaky, it seems to be making the right calls...

In addition, the ec2test package has been modified to inject an associated public IP when creating default NICs.

Finally, the PR contains drive-by fixes for pre-existing flaky tests