### PR TITLE
Add a backoff/retry to queries which fail due to a request limit error

### DIFF
--- a/ec2/responses_test.go
+++ b/ec2/responses_test.go
@@ -13,6 +13,19 @@ var ErrorDump = `
 </Response>
 `
 
+var ErrorRequestLimitExceeded = `
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+   <Errors>
+      <Error>
+         <Code>RequestLimitExceeded</Code>
+         <Message>Request limit exceeded</Message>
+      </Error>
+   </Errors>
+   <RequestID>0503f4e9-bbd6-483c-b54f-c4ae9f3b30f4</RequestID>
+</Response>
+`
+
 // http://goo.gl/Mcm3b
 var RunInstancesExample = `
 <RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">


### PR DESCRIPTION
We started getting RequestLimitErrors running multiple juju bootstraps.
This PR adds a backoff / retry to EC2 API query requests.

Tested using (which failed without this patch)

```
#!/bin/bash

set +x

for i in `seq 20`; do
juju bootstrap aws test$i --credential juju &
done
```