### PR TITLE
Add IPV6 CIDR field to IPPerm payload

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -880,11 +880,12 @@ type SecurityGroupInfo struct {
 //
 // See http://goo.gl/4oTxv for more details.
 type IPPerm struct {
-	Protocol     string              `xml:"ipProtocol"`
-	FromPort     int                 `xml:"fromPort"`
-	ToPort       int                 `xml:"toPort"`
-	SourceIPs    []string            `xml:"ipRanges>item>cidrIp"`
-	SourceGroups []UserSecurityGroup `xml:"groups>item"`
+	Protocol      string              `xml:"ipProtocol"`
+	FromPort      int                 `xml:"fromPort"`
+	ToPort        int                 `xml:"toPort"`
+	SourceIPs     []string            `xml:"ipRanges>item>cidrIp"`
+	SourceIPV6IPs []string            `xml:"ipv6Ranges>item>cidrIpv6"`
+	SourceGroups  []UserSecurityGroup `xml:"groups>item"`
 }
 
 // UserSecurityGroup holds a security group and the owner

--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -32,7 +32,7 @@ const (
 	debug = false
 
 	// apiVersion is the AWS API version used for all EC2 requests.
-	apiVersion = "2015-03-01"
+	apiVersion = "2016-11-15"
 )
 
 // The EC2 type encapsulates operations with a specific EC2 region.
@@ -1000,6 +1000,10 @@ func (ec2 *EC2) authOrRevoke(op string, group SecurityGroup, perms []IPPerm) (re
 		params[prefix+".ToPort"] = strconv.Itoa(perm.ToPort)
 		for j, ip := range perm.SourceIPs {
 			params[prefix+".IpRanges."+strconv.Itoa(j+1)+".CidrIp"] = ip
+		}
+		for j, ip := range perm.SourceIPV6IPs {
+			params[prefix+".Ipv6Ranges."+strconv.Itoa(j+1)+".CidrIpv6"] = ip
+			j++
 		}
 		for j, g := range perm.SourceGroups {
 			subprefix := prefix + ".Groups." + strconv.Itoa(j+1)

--- a/ec2/responses_test.go
+++ b/ec2/responses_test.go
@@ -605,6 +605,45 @@ var DescribeSecurityGroupsDump = `
 </DescribeSecurityGroupsResponse>
 `
 
+// A dump which includes groups within ip permissions and a mix of IPV4 and IPV6 CIDRs.
+var DescribeSecurityGroupsDumpWithIPV6 = `
+<?xml version="1.0" encoding="UTF-8"?>
+<DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
+    <requestId>87b92b57-cc6e-48b2-943f-f6f0e5c9f46c</requestId>
+    <securityGroupInfo>
+        <item>
+            <ownerId>12345</ownerId>
+            <groupName>default</groupName>
+            <groupDescription>default group</groupDescription>
+            <ipPermissions>
+                <item>
+                    <ipProtocol>icmp</ipProtocol>
+                    <fromPort>-1</fromPort>
+                    <toPort>-1</toPort>
+                    <groups>
+                        <item>
+                            <userId>12345</userId>
+                            <groupName>default</groupName>
+                            <groupId>sg-67ad940e</groupId>
+                        </item>
+                    </groups>
+		    <ipRanges>
+                        <item>
+                            <cidrIp>10.0.0.0/24</cidrIp>
+                        </item>
+                    </ipRanges>
+                    <ipv6Ranges>
+                        <item>
+                            <cidrIpv6>2002::1234:abcd:ffff:c0a8:101/64</cidrIpv6>
+                        </item>
+                    </ipv6Ranges>
+                </item>
+            </ipPermissions>
+        </item>
+    </securityGroupInfo>
+</DescribeSecurityGroupsResponse>
+`
+
 // http://goo.gl/QJJDO
 var DeleteSecurityGroupExample = `
 <DeleteSecurityGroupResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">


### PR DESCRIPTION
This PR enables support for IPV6 CIDRs when creating and querying ingress rules.

Note that as the new fields are only recognized by a newer version (which is also happens to be the latest) of the EC2 API, the `apiVersion` constant has been updated accordingly.